### PR TITLE
Stage04 wave hunt

### DIFF
--- a/pipeline/stage04_wavefront_detection/README.md
+++ b/pipeline/stage04_wavefront_detection/README.md
@@ -33,3 +33,4 @@ Input signals and transition event + wavefronts as collections of transitions ti
 |__clustering__|groups trigger events by spatial and temporal distance|`METRIC`, `NEIGHBOUR_DISTANCE`, `MIN_SAMPLES_PER_WAVE`, `TIME_SPACE_RATIO`|
 |__(optical_flow)__|calculates vector velocity field with Horn-Schunck algorithm|`ALPHA`, `MAX_NITER`, `CONVERGENCE_LIMIT`, `GAUSSIAN_SIGMA`, `DERIVATIVE_FILTER`|
 |__(critical_points)__|..|..|
+|__WaveHunt_Cropped__|groups trigger events by unicity and globallity principles|`OPTIMAL_MAX_ABS_TIMELAG`, `ACCEPTABLE_REJECTION_RATE`, `MIN_CH_NUM`|

--- a/pipeline/stage04_wavefront_detection/Snakefile
+++ b/pipeline/stage04_wavefront_detection/Snakefile
@@ -31,6 +31,13 @@ PLOT_TSTOP = config["PLOT_TSTOP"]
 PLOT_CHANNELS = parse_plot_channels(config["PLOT_CHANNELS"], STAGE_INPUT)
 PLOT_FORMAT = config["PLOT_FORMAT"]
 
+if config["DETECTION_BLOCK"] == "WaveHunt_Clustering":
+    BLOCK_ORDER = ["clustering", "optical_flow", "critical_points", "critical_points_clustering", "merge_wave_definitions"]
+
+elif config["DETECTION_BLOCK"] == "WaveHunt_Time":
+    BLOCK_ORDER = ["WaveHunt_Cropped"]
+
+
 METRIC = config["METRIC"]
 TIME_SPACE_RATIO = config["TIME_SPACE_RATIO"]
 NEIGHBOUR_DISTANCE = config["NEIGHBOUR_DISTANCE"]
@@ -43,16 +50,44 @@ GAUSSIAN_SIGMA = config["GAUSSIAN_SIGMA"]
 DERIVATIVE_FILTER = config["DERIVATIVE_FILTER"]
 DETECT_CRITICAL_POINTS = config["DETECT_CRITICAL_POINTS"]
 
-localrules: all, check_input
+
+MAX_ABS_TIMELAG = config["MAX_ABS_TIMELAG"]
+ACCEPTABLE_REJECTION_RATE = config["ACCEPTABLE_REJECTION_RATE"]
+MIN_CH_NUM = config["MIN_CH_NUM"]
+
+
+#localrules: all, check_input
 
 #### Housekeeping ####
+
+wildcard_constraints:
+    rule_name = '\w+'
+
+def locate(str_list, string):
+    print(str_list)
+    print(string)
+    if string in str_list:
+        return [i for i, el in enumerate(str_list) if el == string][0]
+    else:
+        raise ValueError("Can't find rule '{}'! Please check the spelling \
+                          and the config file.".format(string))
+
+def input_file(wildcards):
+    if hasattr(wildcards, 'rule_name'):
+        idx = locate(BLOCK_ORDER, wildcards.rule_name)
+        if idx:
+            return os.path.join(OUTPUT_DIR, BLOCK_ORDER[idx-1],
+                                BLOCK_ORDER[idx-1]+'.'+NEO_FORMAT)
+    elif len(BLOCK_ORDER):
+        return os.path.join(OUTPUT_DIR, BLOCK_ORDER[-1],
+                            BLOCK_ORDER[-1]+'.'+NEO_FORMAT)
+    return os.path.join(STAGE_INPUT)
 
 rule all:
     input:
         check = os.path.join(OUTPUT_DIR, 'input.check'),
-        # configfile = os.path.join('configs', f'config_{PROFILE}.yaml'),
-        data = os.path.join(OUTPUT_DIR, 'merge_wave_definitions', STAGE_OUTPUT),
-        # img = os.path.join(OUTPUT_DIR, 'wave_plots')
+        data = input_file,
+        #configfile = os.path.join('configs', f'config_{PROFILE}.yaml')
     params:
         command = 'ln -s' if USE_LINK_AS_STAGE_OUTPUT else 'cp'
     output:
@@ -208,4 +243,27 @@ checkpoint plot_waves:
                               --img_name {params.img_name} \
                               --time_window {params.time_window} \
                               --colormap {params.colormap}
+        """
+
+
+rule WaveHunt_Cropped:
+    input:
+        data = STAGE_INPUT,
+        script = os.path.join('scripts', 'WaveHunt_Cropped.py'),
+    params:
+        Max_Abs_Timelag = MAX_ABS_TIMELAG,
+        Acceptable_rejection_rate = ACCEPTABLE_REJECTION_RATE,
+        min_ch_num = MIN_CH_NUM,
+
+    output:
+        data = os.path.join('{dir}', 'WaveHunt_Cropped',
+                            '{rule_name}.'+NEO_FORMAT),
+    shell:
+        """
+        {ADD_UTILS}
+        python {input.script} --data "{input.data}" \
+                              --output "{output.data}" \
+                              --min_ch_num {params.min_ch_num} \
+                              --Max_Abs_Timelag {params.Max_Abs_Timelag} \
+                              --Acceptable_rejection_rate {params.Acceptable_rejection_rate} \
         """

--- a/pipeline/stage04_wavefront_detection/configs/config_LENS.yaml
+++ b/pipeline/stage04_wavefront_detection/configs/config_LENS.yaml
@@ -20,8 +20,13 @@ USE_LINK_AS_STAGE_OUTPUT: True
 # Plotting parameters
 PLOT_TSTART: 0  # in s
 PLOT_TSTOP: 10  # in s
-PLOT_CHANNELS: [4040, 5050, 6060]  # int or None. default 'None' -> randomly selected
+PLOT_CHANNELS: [1675, 2181, 1889]  # int or None. default 'None' -> randomly selected
 PLOT_FORMAT: 'png'
+
+# DETECTION BLOCK
+#################
+# Available Blocks: 'WaveHunt_Clustering', 'WaveHunt_Time'
+DETECTION_BLOCK: WaveHunt_Time
 
 # Tigger Filter
 ###############
@@ -63,3 +68,9 @@ DETECT_CRITICAL_POINTS: True
 
 # Critical Point Clustering
 ###########################
+
+#WaveHunt_Time
+###########################
+MAX_ABS_TIMELAG: 0.8 # Maximum reasonable time lag between electrodes (pixels)...
+ACCEPTABLE_REJECTION_RATE: 0.1;
+MIN_CH_NUM: 300

--- a/pipeline/stage04_wavefront_detection/configs/config_template.yaml
+++ b/pipeline/stage04_wavefront_detection/configs/config_template.yaml
@@ -23,6 +23,11 @@ PLOT_TSTOP: 10  # in s
 PLOT_CHANNELS: 'None'  # int or None. default 'None' -> randomly selected
 PLOT_FORMAT: 'png'
 
+# DETECTION BLOCK
+#################
+# Available Blocks: 'WaveHunt_Clustering', 'WaveHunt_Time'
+DETECTION_BLOCK: WaveHunt_Clustering
+
 # Wavefront Clustering
 ######################
 # Using sklearn.cluster.DBSCAN
@@ -55,3 +60,9 @@ DETECT_CRITICAL_POINTS: False
 
 # Critical Point Clustering
 ###########################
+
+#WaveHunt_Time
+###########################
+MAX_ABS_TIMELAG: 0.8 # Maximum reasonable time lag between electrodes (pixels)...
+ACCEPTABLE_REJECTION_RATE: 0.1;
+MIN_CH_NUM: 300

--- a/pipeline/stage04_wavefront_detection/scripts/Params_optimization.py
+++ b/pipeline/stage04_wavefront_detection/scripts/Params_optimization.py
@@ -1,0 +1,139 @@
+
+def Optimal_MAX_ABS_TIMELAG(evts, MAX_ABS_TIMELAG):
+
+    import numpy as np
+    import quantities as pq
+    from utils import load_neo, write_neo, remove_annotations
+    import neo
+
+    UpTrans = evts.times.magnitude
+    ChLabel = evts.array_annotations['channels']
+    DeltaTL = np.diff(UpTrans);
+
+    ####################################################
+    # Compute the time lags matrix looking for optimal MAX_ABS_TIMELAG...
+    # (depends on the distance between electrodes in the array)
+
+    WaveUnique_flag = 0;
+    
+    while WaveUnique_flag == 0: #while there still is at least one non-unique wave...
+    
+        WaveUnique_flag = 1
+        WnW = np.int32(DeltaTL<=MAX_ABS_TIMELAG);
+        ndxBegin_list = np.append(0, np.where(np.diff(WnW)==1)[0]+1)
+        ndxEnd_list = np.append(np.where(np.diff(WnW)==-1)[0]+1, len(UpTrans)-1)
+
+        Wave = [dict() for i in range(len(ndxBegin_list))]
+        for w in range(0, len(ndxBegin_list)):
+            
+            ndx = list(range(ndxBegin_list[w],ndxEnd_list[w]+1))
+            Wave[w] = {'ndx': ndx,
+                       'ch': ChLabel[ndx],
+                       'time': UpTrans[ndx],
+                       'WaveUnique': len(ndx) == len(np.unique(ChLabel[ndx])),
+                       'WaveSize': len(ndx),
+                       'WaveTime': np.mean(UpTrans[ndx])};
+
+            if len(ndx) != len(np.unique(ChLabel[ndx])):
+                WaveUnique_flag = 0
+                break
+            
+        MAX_ABS_TIMELAG = MAX_ABS_TIMELAG*0.75; # rescale the parameter
+    print('max abs timelag', MAX_ABS_TIMELAG)
+    
+    return Wave
+
+def Optima_MAX_IWI(UpTrans, ChLabel, Wave, ACCEPTABLE_REJECTION_RATE):
+
+    import numpy as np
+    import quantities as pq
+    from utils import load_neo, write_neo, remove_annotations
+    import neo
+
+    WaveUnique=list(map(lambda x : x['WaveUnique'], Wave))
+    WaveSize=list(map(lambda x : x['WaveSize'], Wave))
+    WaveTime=list(map(lambda x : x['WaveTime'], Wave))
+
+    nCh = len(np.unique(ChLabel))
+    
+    
+    ####################################################
+    # ExpectedTrans i.e. estimate of the Number of Waves
+    # ExpectedTrans used to estimate/optimize IWI    
+    TransPerCh_Idx, TransPerCh_Num = np.unique(ChLabel, return_counts=True)
+    ExpectedTrans = np.median(TransPerCh_Num[np.where(TransPerCh_Num != 0)]);
+    
+    ## Wave Hunt -- step 1: Compute the Time Lags, Find Unique Waves --> WaveCollection1
+    IWI = np.diff(WaveTime);          # IWI = Inter-Wave-Interval...
+
+
+    ##Recollect small-waves in full waves (involving a wider area).
+    MAX_IWI = np.max(IWI)*0.5
+    OneMoreLoop = 1;
+    
+    while OneMoreLoop:
+
+        WnW = np.int32(IWI<=MAX_IWI);
+        ndxBegin_list = np.append(0, np.where(np.diff(WnW)==1)[0]+1)
+        ndxEnd_list = np.append(np.where(np.diff(WnW)==-1)[0]+1, len(WaveTime)-1)
+
+        FullWave = []
+
+        num_iter = -1
+        for w in range(0, len(ndxBegin_list)):
+            num_iter = num_iter +1
+            ndx = list(range(ndxBegin_list[w],ndxEnd_list[w]+1))
+            Full_ndx = []
+            for elem in ndx:
+                Full_ndx.extend(Wave[elem]['ndx'])
+            Full_ndx = np.int64(Full_ndx)
+            
+            FullWave.append({'ndx': Full_ndx,
+                           'times': UpTrans[Full_ndx],
+                           'ch': ChLabel[Full_ndx],
+                           'WaveUnique': len(Full_ndx) == len(np.unique(ChLabel[Full_ndx])),
+                           'WaveSize': len(Full_ndx),
+                           'WaveTime': np.mean(UpTrans[Full_ndx]),
+                           'WaveUniqueSize': len(np.unique(ChLabel[Full_ndx]))
+                           });
+
+            # save as single waves isolated transitions.
+
+            
+            if ndxEnd_list[w]+1 != len(WaveTime):
+                for j in range(ndxEnd_list[w]+1, ndxBegin_list[w+1]):
+                    ndx = [j]
+                    Full_ndx = []
+                    for elem in ndx:
+                        Full_ndx.extend(Wave[elem]['ndx'])
+                    Full_ndx = np.int64(Full_ndx)
+                    
+                    FullWave.append({'ndx': Full_ndx,
+                                   'times': UpTrans[Full_ndx],
+                                   'ch': ChLabel[Full_ndx],
+                                   'WaveUnique': len(Full_ndx) == len(np.unique(ChLabel[Full_ndx])),
+                                   'WaveSize': len(Full_ndx),
+                                   'WaveTime': np.mean(UpTrans[Full_ndx]),
+                                   'WaveUniqueSize': len(np.unique(ChLabel[Full_ndx]))
+                                   });
+
+            
+        FullWaveUnique = list(map(lambda x : x['WaveUnique'], FullWave))
+        BadWavesNum = len(FullWaveUnique) - len(np.where(FullWaveUnique)[0]);
+        OneMoreLoop = 0;
+
+        if len(FullWaveUnique) <= ExpectedTrans: # If not we have an artifactual amplification of small waves...
+            if float(BadWavesNum)/len(FullWaveUnique) > ACCEPTABLE_REJECTION_RATE:
+                if np.min(FullWaveUnique) == 0: # at lest a Wave non-unique
+                    MAX_IWI = MAX_IWI*0.75;
+                    OneMoreLoop = 1;
+                else: # only unique waves
+                    if np.max(WaveSize) < nCh: # at least one wave MUST BE GLOBAL (i.e. involving the full set of electrodes)
+                        MAX_IWI = MAX_IWI*1.25;
+                        OneMoreLoop = 1;
+    return(FullWave)
+
+
+
+
+

--- a/pipeline/stage04_wavefront_detection/scripts/UpTrans_Detector.py
+++ b/pipeline/stage04_wavefront_detection/scripts/UpTrans_Detector.py
@@ -1,0 +1,24 @@
+def ReadPixelData(events, DIM_X, DIM_Y, spatial_scale):
+
+    import numpy as np
+    from utils import remove_annotations
+    import neo
+    
+    PixelLabel = events.array_annotations['y_coords'] * DIM_Y + events.array_annotations['x_coords']
+    UpTrans = events.times
+    Sorted_Idx = np.argsort(UpTrans)
+    UpTrans = UpTrans[Sorted_Idx]
+    PixelLabel = PixelLabel[Sorted_Idx]
+
+    UpTrans_Evt = neo.Event(times=UpTrans,
+                name='UpTrans',
+                array_annotations={'channels':PixelLabel},
+                description='Transitions from down to up states. '\
+                           +'Annotated with the channel id ("channels")',
+                Dim_x = DIM_X,
+                Dim_y = DIM_Y,
+                spatial_scale = spatial_scale)
+    remove_annotations(UpTrans_Evt, del_keys=['nix_name', 'neo_name'])
+    UpTrans_Evt.annotations.update(events.annotations)
+    
+    return(UpTrans_Evt)

--- a/pipeline/stage04_wavefront_detection/scripts/WaveCleaning.py
+++ b/pipeline/stage04_wavefront_detection/scripts/WaveCleaning.py
@@ -1,0 +1,344 @@
+import os
+import numpy as np
+import quantities as pq
+import argparse
+import matplotlib.pyplot as plt
+import pandas as pd
+from scipy import io
+import math
+from utils import AnalogSignal2ImageSequence, load_neo, save_plot
+from utils import load_neo, write_neo, remove_annotations
+from utils import none_or_str, none_or_float
+import neo
+
+
+def Neighbourhood_Search(h, w):
+    
+    #LOCALITY criteria
+    neighbors = np.zeros([h*w, 4]);
+    elements = np.array(range(0, h*w), dtype = 'int32')
+    neighbors[:,0] = elements + 1 # right
+    neighbors[:,1] = elements - 1 # left
+    neighbors[:,2] = elements + w # down
+    neighbors[:,3] = elements - w # up
+    np.where(neighbors[:,0]>=w, neighbors[:,0], np.nan)
+    np.where(neighbors[:,1]<0, neighbors[:,1], np.nan)
+    np.where(neighbors[:,2]>h*w, neighbors[:,2], np.nan)
+    np.where(neighbors[:,3]<0, neighbors[:,3], np.nan)
+
+    return(neighbors)
+
+def ChannelCleaning(Wave, neighbors):
+
+    # --- (1) First CHANNEL CLEANING: check the TIME DISTANCE BETWEEN REPETITIONS IN A WAVE
+
+    chs = Wave['ch'];            
+    nhc_pixel, nhc_count = np.unique(chs, return_counts=True)
+    rep = np.where(nhc_count > 1.)[0]; # channels index where the wave pass more than once           
+
+    k = 0
+
+
+    
+    while k < len(rep):
+        
+        i=rep[k];
+        
+        repeted_index = np.where(chs == nhc_pixel[i])[0] # where i have repetitions
+        
+        timeStamp = Wave['times'][repeted_index].magnitude #UpTrans[idx];
+        
+        if np.max(np.diff(timeStamp))<0.125: #if repeted transition happen to be close in time                   
+            # delta waves freqeunci is 1-4Hz -> minimum distance between two waves = 0.250s
+            # open a time-window around each occurrence of i and check
+            # how many members of the clan are in the time-window
+            
+            nClan=[];
+            idx_noClan = []
+            neigh_coll =  neighbors[nhc_pixel[i]]
+            neigh_coll_idx = []
+            for n in neigh_coll:
+                neigh_coll_idx.extend(np.where(Wave['ch'] == n)[0])
+
+            for idx, time in enumerate(timeStamp): # for each repetintion in the selected channel 
+                time_window=[time-0.125, time+0.125];
+                clan = len(np.intersect1d(Wave['times'][neigh_coll_idx] > time_window[0],
+                                          Wave['times'][neigh_coll_idx] < time_window[1]))
+                if clan == 0:
+                    idx_noClan.append(idx)
+
+            if len(idx_noClan)> 0:
+                del_idx = repeted_index[idx_noClan]
+                          
+                del_idx = repeted_index[idx] # indexes to be deleted
+                Wave['ndx'] = np.delete(Wave['ndx'], del_idx)
+                Wave['times'] = np.delete(Wave['times'], del_idx)
+                Wave['ch'] = np.delete(Wave['ch'], del_idx)
+                Wave['WaveUnique'] = 1
+                Wave['WaveTime'] = np.mean(Wave['times'])
+                Wave['WaveSize'] = len(Wave['ndx'])
+
+                chs = Wave['ch'];
+                nhc_pixel, nhc_count = np.unique(chs, return_counts=True)
+                if nhc_count[i] > 1:
+                    k = k-1
+        k = k+1
+    return(Wave)
+
+def Clean_SegmentedWave(seg, neighbors):
+
+    delSeg=[];
+               
+    for i in range(0,len(seg)): # CHECK if SEGMENTS have to be cleaned
+        
+        # 1) clean non-unique segments
+        if len(np.unique(seg[i]['ch'])) != len(seg[i]['ch']): #if  the subset of transition is NOT unique
+            # --> 'CLEAN', i.e. scan the transition sequence and
+            # find repetition of channels
+        
+            delCh = Clean_NonUniqueWave(seg[i], neighbors)
+            
+            if len(delCh):
+                seg[i]['ch'] = np.delete(seg[i]['ch'], np.unique(delCh))
+                seg[i]['ndx']= np.delete(seg[i]['ndx'], np.unique(delCh)); 
+                seg[i]['times']= np.delete(seg[i]['times'], np.unique(delCh)); 
+
+
+        # 2) clean channels non-LocallyConnected (see neighbors)                    
+        if len(seg[i]['ch'])<=5: # 5 is min(len(neighbors{:}{2})
+            delList=[];
+            for ch_idx, ch in enumerate(seg[i]['ch']):
+                if not (np.intersect1d(neighbors[ch], np.setdiff1d(seg[i]['ch'],ch))).size:
+                    delList.append(ch_idx);
+            if len(delList):
+                seg[i]['ch']= np.delete( seg[i]['ch'],delList)
+                seg[i]['ndx']= np.delete( seg[i]['ndx'],delList)
+                seg[i]['times']= np.delete( seg[i]['times'],delList)
+
+        # 3) prepere to remove empty segments
+        if len(seg[i]['ndx'])==0:
+            delSeg.append(i);
+
+
+    # remove empty secments
+    if delSeg:
+       seg=np.delete(seg,delSeg);
+    
+    return(seg)
+
+
+def Clean_NonUniqueWave(Wave, neighbors):              
+
+    # 1) clean non-unique segments
+    delCh=[];
+
+    if len(np.unique(Wave['ch'])) != len(Wave['ch']): #if  the subset of transition is NOT unique
+        # --> 'CLEAN', i.e. scan the transition sequence and
+        # find repetition of channels
+        
+        delCh=[];
+
+        involved_ch, repetition_count = np.unique(Wave['ch'], return_counts = True)
+        involved_ch = involved_ch[np.where(repetition_count > 1)[0]] # channels non unique
+
+        for rep_ch in involved_ch: # for each non unique channel delete repeted channels                                                  
+            t0Clan=0;
+            nClan=0;
+            neigh = neighbors[rep_ch]
+            
+            for n in neigh:
+                tClan = Wave['times'][np.where(Wave['ch']==n)[0]]
+                if tClan.size > 0:
+                    nClan=nClan+1; 
+                    t0Clan=t0Clan+np.mean(tClan);
+                
+            if nClan > 0:
+                t0Clan= np.float64(t0Clan)/nClan;
+                tCh = Wave['times'][np.where(Wave['ch']==rep_ch)[0]]
+                index = np.where(Wave['ch']==rep_ch)[0][np.argmin(abs(tCh-t0Clan))];                                
+                delCh.extend(np.setdiff1d(np.where(Wave['ch']==rep_ch)[0], index));
+                
+    return(delCh)
+
+
+def CleanWave(UpTrans,ChLabel, neighbors,  FullWave):
+
+    FullWaveUnique=list(map(lambda x : x['WaveUnique'], FullWave))
+    FullWaveSize=list(map(lambda x : x['WaveSize'], FullWave))
+    FullWaveTime=list(map(lambda x : x['WaveTime'], FullWave))
+
+    nPixel = len(np.unique(ChLabel))
+    nw=0;
+
+    
+    while nw<len(FullWave): # for each wave
+        
+
+        if len(FullWave[nw]['ch']) != len(np.unique(FullWave[nw]['ch'])):
+            
+            # CLEAN wave channels
+            FullWave[nw] = ChannelCleaning(FullWave[nw], neighbors)
+
+
+            # Look for CANDIDATE SEGMENTS                            
+            #Check the time difference between transitions
+            delta=np.diff(FullWave[nw]['times']);
+            mD=np.mean(delta);
+            stdD=np.std(delta);
+            THR=mD+3*stdD;
+
+            Segments_Idx = np.where(delta>THR)[0] # where there is a larger sepration between transitions
+            
+            if Segments_Idx.size: # --- IDENTIFY SEGMENTS
+
+                #create SEGMENTS i.e. candidate NEW waves
+                n_candidate_waves=Segments_Idx.size +1; 
+                istart=0;  i=0;
+
+                seg = []
+                for b in Segments_Idx:
+                    seg.append({'ndx': list(range(istart,b+1)),
+                                'ch': FullWave[nw]['ch'][istart:b+1],
+                                'times': FullWave[nw]['times'][istart:b+1].magnitude});
+                    istart=b+1;
+                seg.append({'ndx': list(range(istart,len(FullWave[nw]['ch']))),
+                            'ch': FullWave[nw]['ch'][istart:len(FullWave[nw]['ch'])],
+                            'times': FullWave[nw]['times'][istart:len(FullWave[nw]['times'])].magnitude})
+
+                
+                # --- CLEAN SEGMENTS---
+                seg = Clean_SegmentedWave(seg, neighbors)
+
+                ##############################################################
+                # fino a qui
+                n_candidate_waves=len(seg); # update the value in 'segments' = number of segments
+
+                # coalescence of segments if no repetitions with adjacent(s) one(s)
+                # N.B. a "small" intersection is admitted
+                i=0;
+                while i<(n_candidate_waves-1): # for each wave
+                    if len(np.intersect1d(seg[i]['ch'],seg[i+1]['ch'])) <= np.floor(1./4.*np.min([len(seg[i]['ch']),len(seg[i+1]['ch'])])):
+
+                        # CANDIDATE SEGMENTS for COALESCENCE
+                        # check also if distance between segments'border is smaller than 250ms = 1/4Hz
+
+                        distance = seg[i+1]['times'][0] - seg[i]['times'][len(seg[i]['times'])-1];
+
+                        if distance>=0.250: # check also if distance between segments'border is smaller than 250ms = 1/4Hz
+                            # FREQUENCY ALERT: distance compatible with SWA, the two segments should be kept separated
+                            i=i+1; #increment the pointer only if no coalescence is made
+                        else:
+                            # COALESCENCE
+                            # The two segments are close enough that can be merged into a single wave
+                            # (consider them separated waves would mean the SWA frequency is larger than 4Hz)
+                            # COALESCENCE of consecutive SEGMENTS
+
+                            merged = {'ch': np.append(seg[i]['ch'], seg[i+1]['ch']),
+                                      'ndx': np.append(seg[i]['ndx'], seg[i+1]['ndx']),
+                                      'times': np.append(seg[i]['times'], seg[i+1]['times'])}
+                             
+                            # CHECK for REPETITIONS (and treat them as usual...
+                            # looking at the meanTime in the Clan)
+                            
+                            delCh = Clean_NonUniqueWave(merged, neighbors)
+
+                            if len(np.unique(delCh))>0:
+                                merged['ch'] = np.delete(merged['ch'], np.unique(delCh));
+                                merged['ndx']= np.delete(merged['ndx'], np.unique(delCh));
+                                merged['times']= np.delete(merged['times'], np.unique(delCh));
+
+                            seg[i]=merged; # COALESCENCE
+                            seg=np.delete(seg, i+1); # coalesced segments are at index i, segment at index i+1 is REMOVED
+                            n_candidate_waves=n_candidate_waves-1;
+                    else: # consecutive segments intersect too much...
+                        i=i+1; #increment the pointer only if no coalescence is made
+
+                    
+
+                # $$$$$ N.B. the number of segments has to be updated
+                NewFullWave = []
+                for i in range(0,n_candidate_waves):
+                    #ndx = []
+                    #for elem in seg[i]['ndx']:
+                    #    ndx.append(FullWave[nw]['ndx'][elem])
+                    ndx = FullWave[nw]['ndx'][seg[i]['ndx']]
+                    
+                    NewFullWave.append({'ndx': ndx, 'times': UpTrans[ndx], 'ch': ChLabel[ndx],
+                                        'WaveUnique':1, 'WaveSize': len(ndx), 'WaveTime': np.mean(UpTrans[ndx])});
+
+
+                    #NewFullWaveUnique.append(1); # update the logical value (...we are "cleaning" the waves)
+            else: # NO SEGMENTS identified -->
+                # repeated chiannels are due to noise (and not to the presence of more than one wave)
+                # CLEAN the wave, i.e. keep only the first channel occurrance
+                delCh = Clean_NonUniqueWave(FullWave[nw], neighbors)
+                
+                if len(delCh):
+                    FullWave[nw]['ch'] = np.delete(FullWave[nw]['ch'], np.unique(delCh))
+                    FullWave[nw]['ndx']= np.delete(FullWave[nw]['ndx'], np.unique(delCh)); 
+                    FullWave[nw]['times']= np.delete(FullWave[nw]['times'], np.unique(delCh)); 
+
+                
+                # wave is "cleaned"; store the updated wave
+                ndx = FullWave[nw]['ndx']
+                NewFullWave = {'ndx': ndx, 'times': UpTrans[ndx], 'ch': ChLabel[ndx],
+                               'WaveUnique': 1, 'WaveSize': len(ndx), 'WaveTime':np.mean(UpTrans[ndx])};
+                
+            # --- REPLACE CurrentWave with NewWave(s)
+            # [its segments or its 'cleaned' version]
+            
+            if nw != 0:
+                Pre = FullWave[:].copy()
+                FullWave=Pre[0:nw].copy()
+                FullWave.extend(NewFullWave)
+                FullWave.extend(Pre[nw+1:]);#end
+            else:               
+                Pre = FullWave[:].copy()
+                FullWave = NewFullWave.copy()
+                FullWave.extend(Pre[nw+1:]);#end
+                
+            # --- INCREMENT the pointer
+            if len(NewFullWave)>0: # SEGMENTS ARE NEW WAVES
+                nw = nw+len(NewFullWave); # increment (point at the next wave)
+            else: # no segments identified, the current wave is a New Wave, because it has been cleaned
+                nw=nw+1; # increment (point at the next wave)
+        else:
+            nw=nw+1; # increment (point at the next wave) [current wave is already unique]
+
+    return(FullWave)
+
+
+def RemoveSmallWaves(Evts_UpTrans, MIN_CH_NUM, FullWave):
+
+    UpTrans = Evts_UpTrans.times
+    ChLabel = Evts_UpTrans.array_annotations['channels']
+    
+    nCh = len(np.unique(ChLabel))
+    DIM_X = Evts_UpTrans.annotations['Dim_x']
+    DIM_Y = Evts_UpTrans.annotations['Dim_y']
+    spatial_scale = Evts_UpTrans.annotations['spatial_scale']
+
+    FullWaveUnique=list(map(lambda x : x['WaveUnique'], FullWave))
+    FullWaveSize=list(map(lambda x : x['WaveSize'], FullWave))
+    FullWaveTime=list(map(lambda x : x['WaveTime'], FullWave))
+
+
+    ## Find Maxima and Minima in the histogram of FullWaveSize
+ 
+
+    # Remove small waves and those rejected...
+    temp = [FullWaveUnique[i]==1 and FullWaveSize[i] >= MIN_CH_NUM  for i in range(0, len(FullWaveUnique))]
+    ndx = np.where(np.array(temp))[0];
+    RejectedWaves = len(FullWaveUnique) - len(ndx); # rejected beacuse too small
+                                                    # (i.e. involving too few channels)
+    Wave = []
+ 
+    for idx in ndx:
+        Wave.append(FullWave[idx]);
+
+    return Wave
+
+    
+
+
+

--- a/pipeline/stage04_wavefront_detection/scripts/WaveCleaning.py
+++ b/pipeline/stage04_wavefront_detection/scripts/WaveCleaning.py
@@ -281,8 +281,8 @@ def CleanWave(UpTrans,ChLabel, neighbors,  FullWave):
                 
                 # wave is "cleaned"; store the updated wave
                 ndx = FullWave[nw]['ndx']
-                NewFullWave = {'ndx': ndx, 'times': UpTrans[ndx], 'ch': ChLabel[ndx],
-                               'WaveUnique': 1, 'WaveSize': len(ndx), 'WaveTime':np.mean(UpTrans[ndx])};
+                NewFullWave = [{'ndx': ndx, 'times': UpTrans[ndx], 'ch': ChLabel[ndx],
+                               'WaveUnique': 1, 'WaveSize': len(ndx), 'WaveTime':np.mean(UpTrans[ndx])}];
                 
             # --- REPLACE CurrentWave with NewWave(s)
             # [its segments or its 'cleaned' version]

--- a/pipeline/stage04_wavefront_detection/scripts/WaveHunt_Cropped.py
+++ b/pipeline/stage04_wavefront_detection/scripts/WaveHunt_Cropped.py
@@ -1,0 +1,102 @@
+import os
+import numpy as np
+import quantities as pq
+import argparse
+import matplotlib.pyplot as plt
+import pandas as pd
+from scipy import io
+import math
+from utils import AnalogSignal2ImageSequence, load_neo, save_plot
+from utils import load_neo, write_neo, remove_annotations
+from utils import none_or_str, none_or_float
+import neo
+
+from UpTrans_Detector import ReadPixelData
+from Params_optimization import Optimal_MAX_ABS_TIMELAG, Optima_MAX_IWI
+#from Optimal_MAX_ABS_TIMELAG import Optimal_MAX_ABS_TIMELAG
+#from MAX_IWI_Search import MAX_IWI_Search
+#from WaveHuntTimes_UnicityPrinciple import WaveHuntTimes_UnicityPrinciple, Neighbourhood_Search
+#from WaveHuntTimes_Globality import WaveHuntTimes_Globality
+from WaveCleaning import RemoveSmallWaves, CleanWave, Neighbourhood_Search
+# ======================================================================================#
+
+# LOAD input data
+if __name__ == '__main__':
+    
+    CLI = argparse.ArgumentParser(description=__doc__,
+                      formatter_class=argparse.RawDescriptionHelpFormatter)
+    CLI.add_argument("--data", nargs='?', type=str, required=True,
+                        help="path to input data in neo format")
+    CLI.add_argument("--output", nargs='?', type=str, required=True,
+                        help="path of output file")
+    CLI.add_argument("--Max_Abs_Timelag", nargs='?', type=float, default=0.8,
+                        help="Maximum reasonable time lag between electrodes (pixels)")
+    CLI.add_argument("--Acceptable_rejection_rate", nargs='?', type=float, default=0.1,
+                        help=" ")
+    CLI.add_argument("--min_ch_num", nargs='?', type=float, default=300,
+                        help="minimum number of channels involved in a wave")
+  
+    args = CLI.parse_args()
+    block = load_neo(args.data)
+    block = AnalogSignal2ImageSequence(block)
+    imgseq = block.segments[0].imagesequences[-1]
+    
+    DIM_X, DIM_Y = np.shape(imgseq[0])
+    spatial_scale = imgseq.spatial_scale
+    
+    asig = block.segments[0].analogsignals[-1]
+    evts = [ev for ev in block.segments[0].events if ev.name== 'Transitions']
+    if len(evts):
+        evts = evts[0]
+    else:
+        raise InputError("The input file does not contain any 'Transitions' events!")
+    
+    # Transform the ouptut of stage 3in a more suitable mode
+    UpTrans_Evt = ReadPixelData(evts, DIM_X, DIM_Y, spatial_scale)
+
+    # search for the optimal abs timelag
+    Waves_Inter = Optimal_MAX_ABS_TIMELAG(UpTrans_Evt, args.Max_Abs_Timelag)
+    
+    # search for the best max_IWI param
+    Waves_Inter = Optima_MAX_IWI(UpTrans_Evt.times, UpTrans_Evt.array_annotations['channels'], Waves_Inter, args.Acceptable_rejection_rate)
+
+    # Unicity principle refinement
+    neighbors = Neighbourhood_Search(UpTrans_Evt.annotations['Dim_x'], UpTrans_Evt.annotations['Dim_y'])
+    Waves_Inter = CleanWave(UpTrans_Evt.times, UpTrans_Evt.array_annotations['channels'], neighbors, Waves_Inter)
+
+    # Globality principle
+    Wave = RemoveSmallWaves(UpTrans_Evt, args.min_ch_num, Waves_Inter)
+
+
+        # Create an array with the beginning time of each wave
+    # Saves the array in a 'BeginTime.txt' file in the path folder
+
+    Waves = []
+    Times = []
+    Label = []
+    Pixels = []
+    
+    for i in range(0,len(Wave)):
+        Times.extend(Wave[i]['times'])
+        Label.extend(np.ones([len(Wave[i]['ndx'])])*i)
+        Pixels.extend(Wave[i]['ch'])
+
+    Times = Times*(Wave[0]['times'].units)
+    waves = neo.Event(times=Times.rescale(pq.s),
+                    labels=np.int64(Label),
+                    name='Wavefronts',
+                    array_annotations={'channels':Pixels,
+                                       'x_coords':[p % DIM_Y for p in Pixels],
+                                       'y_coords':[np.floor(p/DIM_Y) for p in Pixels]},
+                    description='Transitions from down to up states. '\
+                               +'Labels are ids of wavefronts. '
+                               +'Annotated with the channel id ("channels") and '\
+                               +'its position ("x_coords", "y_coords").',
+                    spatial_scale = UpTrans_Evt.annotations['spatial_scale'])
+
+    #remove_annotations(waves, del_keys=['nix_name', 'neo_name'])
+    waves.annotations.update(evts.annotations)
+    remove_annotations(waves, del_keys=['nix_name', 'neo_name'])
+
+    block.segments[0].events.append(waves)
+    write_neo(args.output, block)


### PR DESCRIPTION
The “Wave Hunt”  pipeline consists in determining a collection of “candidate” waves by “cutting” appropriately the event sequence UpTrans.  This analysis makes two prior hypotheses: 1) unicity principle i.e. a wave cannot contain more than one upward front in the same channel and 2) globally principle i.e. the requirement of having at least one collective wave (a wave involving the full set of selected channels).  

The user should be able to choose whether to use this method (WaveHunt_Time) or the one already implemented (WaveHunt_Clustering) in the config file. If this method is chosen, the user needs to set 3 parameters (ACCEPTABLE_REJECTION_RATE, MAX_ABS_TIMELAG, MIN_CH_NUM).

There is one main script, WaveHunt_Cropped.py, that calls other function implemented in UpTrans_Detector.py, WaveCleaning.py, Params_optimization.py.
