### PR TITLE
Added action to mirror to EBRAINS gitlab

### DIFF
--- a/.github/workflows/ebrains.yml
+++ b/.github/workflows/ebrains.yml
@@ -1,0 +1,26 @@
+name: Mirror to EBRAINS
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  sync_to_ebrains:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'NeuralEnsemble' }}
+    steps:
+      - name: syncmaster
+        uses: wei/git-sync@v3
+        with:
+          source_repo: "NeuralEnsemble/cobrawap"
+          source_branch: "master"
+          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/neuralensemble/cobrawap.git"
+          destination_branch: "master"
+
+      - name: synctags
+        uses: wei/git-sync@v3
+        with:
+          source_repo: "NeuralEnsemble/cobrawap"
+          source_branch: "refs/tags/*"
+          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/neuralensemble/cobrawap.git"
+          destination_branch: "refs/tags/*"


### PR DESCRIPTION
This is a PR that adds an action that should mirror the repo to NeuralEnsemble/corbawap on each update to the master branch.