### PR TITLE
Changing the logic for 'input.check' files creation

### DIFF
--- a/cobrawap/pipeline/stage01_data_entry/scripts/check_input.py
+++ b/cobrawap/pipeline/stage01_data_entry/scripts/check_input.py
@@ -1,20 +1,21 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
 import numpy as np
 import argparse
 from pathlib import Path
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 from utils.neo_utils import analogsignal_to_imagesequence, imagesequence_to_analogsignal
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -32,22 +33,24 @@ if __name__ == '__main__':
     asig2 = imagesequence_to_analogsignal(imgseq)
 
     if asig.shape != asig2.shape:
-        raise ValueError("AnalogSignal doesn't include empty grid sites. "
+        raise ValueError("AnalogSignal does not include empty grid sites. "
                       + f"Reshape {asig.shape} to {asig2.shape} according to "
                          "x/y_coords. You may use `add_empty_sites_to_analogsignal` "
                          "from the utils.neo_utils module.")
 
-    print('Recording Time:\t\t', asig.t_stop - asig.t_start)
-    print('Sampling Rate:\t\t', asig.sampling_rate)
-    print('Spatial Scale:\t\t', asig.annotations['spatial_scale'])
+    print("Recording Time:\t\t", asig.t_stop - asig.t_start)
+    print("Sampling Rate:\t\t", asig.sampling_rate)
+    print("Spatial Scale:\t\t", asig.annotations["spatial_scale"])
 
     num_channels = np.count_nonzero(~np.isnan(np.sum(asig, axis=0)))
-    print('Number of Channels:\t', num_channels)
+    print("Number of Channels:\t", num_channels)
 
-    x_coords = asig.array_annotations['x_coords']
-    y_coords = asig.array_annotations['y_coords']
+    x_coords = asig.array_annotations["x_coords"]
+    y_coords = asig.array_annotations["y_coords"]
 
     dim_x, dim_y = np.max(x_coords)+1, np.max(y_coords)+1
 
-    print('Grid Dimensions:\t', f'{dim_x} x {dim_y}')
-    print('Empty Grid Sites:\t', dim_x*dim_y - num_channels)
+    print("Grid Dimensions:\t", f'{dim_x} x {dim_y}')
+    print("Empty Grid Sites:\t", dim_x*dim_y - num_channels)
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stage02_processing/scripts/check_input.py
+++ b/cobrawap/pipeline/stage02_processing/scripts/check_input.py
@@ -1,6 +1,5 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
@@ -8,13 +7,15 @@ import numpy as np
 import argparse
 from pathlib import Path
 import quantities as pq
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -28,15 +29,17 @@ if __name__ == '__main__':
 
     asig = block.segments[0].analogsignals[0]
 
-    print('Recording Time:\t\t', asig.t_stop - asig.t_start)
-    print('Sampling Rate:\t\t', asig.sampling_rate)
-    print('Spatial Scale:\t\t', asig.annotations['spatial_scale'])
+    print("Recording Time:\t\t", asig.t_stop - asig.t_start)
+    print("Sampling Rate:\t\t", asig.sampling_rate)
+    print("Spatial Scale:\t\t", asig.annotations["spatial_scale"])
 
     num_channels = np.count_nonzero(~np.isnan(np.sum(asig, axis=0)))
-    print('Number of Channels:\t', num_channels)
+    print("Number of Channels:\t", num_channels)
 
-    x_coords = asig.array_annotations['x_coords']
-    y_coords = asig.array_annotations['y_coords']
+    x_coords = asig.array_annotations["x_coords"]
+    y_coords = asig.array_annotations["y_coords"]
     dim_x, dim_y = np.max(x_coords)+1, np.max(y_coords)+1
-    print('Grid Dimensions:\t', f'{dim_x} x {dim_y}')
-    print('Empty Grid Sites:\t', dim_x*dim_y - num_channels)
+    print("Grid Dimensions:\t", f'{dim_x} x {dim_y}')
+    print("Empty Grid Sites:\t", dim_x*dim_y - num_channels)
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stage03_trigger_detection/scripts/check_input.py
+++ b/cobrawap/pipeline/stage03_trigger_detection/scripts/check_input.py
@@ -1,6 +1,5 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
@@ -8,13 +7,15 @@ import numpy as np
 import argparse
 from pathlib import Path
 import quantities as pq
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -28,14 +29,16 @@ if __name__ == '__main__':
 
     asig = block.segments[0].analogsignals[0]
 
-    x_coords = asig.array_annotations['x_coords']
-    y_coords = asig.array_annotations['y_coords']
+    x_coords = asig.array_annotations["x_coords"]
+    y_coords = asig.array_annotations["y_coords"]
 
-    print('Recording Time:\t\t', asig.t_stop - asig.t_start)
-    print('Sampling Rate:\t\t', asig.sampling_rate)
+    print("Recording Time:\t\t", asig.t_stop - asig.t_start)
+    print("Sampling Rate:\t\t", asig.sampling_rate)
     num_channels = np.count_nonzero(~np.isnan(np.sum(asig, axis=0)))
-    print('Number of Channels:\t', num_channels)
+    print("Number of Channels:\t", num_channels)
 
     dim_x, dim_y = np.max(x_coords)+1, np.max(y_coords)+1
-    print('Grid Dimensions:\t', f'{dim_x} x {dim_y}')
-    print('Empty Grid Sites:\t', dim_x*dim_y - num_channels)
+    print("Grid Dimensions:\t", f'{dim_x} x {dim_y}')
+    print("Empty Grid Sites:\t", dim_x*dim_y - num_channels)
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stage04_wave_detection/scripts/check_input.py
+++ b/cobrawap/pipeline/stage04_wave_detection/scripts/check_input.py
@@ -1,6 +1,5 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
@@ -8,14 +7,16 @@ import numpy as np
 import argparse
 from pathlib import Path
 import quantities as pq
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 from snakemake.logging import logger
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -29,23 +30,25 @@ if __name__ == '__main__':
 
     asig = block.segments[0].analogsignals[0]
 
-    # print('Recording Time:\t\t', asig.t_stop - asig.t_start)
-    # print('Sampling Rate:\t\t', asig.sampling_rate)
-    # print('Spatial Scale:\t\t', asig.annotations['spatial_scale'])
+    # print("Recording Time:\t\t", asig.t_stop - asig.t_start)
+    # print("Sampling Rate:\t\t", asig.sampling_rate)
+    # print("Spatial Scale:\t\t", asig.annotations["spatial_scale"])
 
-    evts = block.filter(name='transitions', objects="Event")
+    evts = block.filter(name="transitions", objects="Event")
 
     if not len(evts):
-        raise ValueError("No 'transitions' events found!")
+        raise ValueError("No `transitions` events found!")
     evt = evts[0]
 
-    if not 'UP' in evt.labels:
-        logger.warning("No transitions labeled 'UP' found!")
-        # raise KeyError("No transitions labeled 'UP' found!")
+    if not "UP" in evt.labels:
+        logger.warning("No transitions labeled `UP` found!")
+        # raise KeyError("No transitions labeled `UP` found!")
 
-    up_channels = np.unique(evt.array_annotations['channels'])
+    up_channels = np.unique(evt.array_annotations["channels"])
     num_channels = np.count_nonzero(~np.isnan(np.sum(asig, axis=0)))
     print(f'{len(up_channels)} of {num_channels} channels show UP transitions.')
 
-    evt.array_annotations['x_coords']
-    evt.array_annotations['y_coords']
+    evt.array_annotations["x_coords"]
+    evt.array_annotations["y_coords"]
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stage05_channel_wave_characterization/scripts/check_input.py
+++ b/cobrawap/pipeline/stage05_channel_wave_characterization/scripts/check_input.py
@@ -1,6 +1,5 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
@@ -10,18 +9,20 @@ from pathlib import Path
 import quantities as pq
 import warnings
 import re
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 from utils.parse import none_or_str
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
-CLI.add_argument("--event_name", "--EVENT_NAME", nargs='?', type=none_or_str, default=None,
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
+CLI.add_argument("--event_name", "--EVENT_NAME", nargs="?", type=none_or_str, default=None,
                  help="name of neo.Event to analyze (must contain waves)")
-CLI.add_argument("--measures", "--MEASURES", nargs='+', type=none_or_str, default=None,
+CLI.add_argument("--measures", "--MEASURES", nargs="+", type=none_or_str, default=None,
                  help="list of measure names to apply")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -30,12 +31,12 @@ if __name__ == '__main__':
         print("More than one Segment found; all except the first one " \
             + "will be ignored.")
 
-    evts = block.filter(name='wavefronts', objects="Event")
+    evts = block.filter(name="wavefronts", objects="Event")
     if not len(evts):
-        raise ValueError("No 'wavefronts' events found!")
+        raise ValueError("No `wavefronts` events found!")
 
     evt = evts[0]
-    evt = evt[evt.labels != '-1']
+    evt = evt[evt.labels != "-1"]
     num_waves = len(np.unique(evt.labels))
 
     if num_waves:
@@ -43,16 +44,19 @@ if __name__ == '__main__':
     else:
         raise ValueError("There are no waves detected!")
 
-    evt.array_annotations['x_coords']
-    evt.array_annotations['y_coords']
-    evt.annotations['spatial_scale']
+    evt.array_annotations["x_coords"]
+    evt.array_annotations["y_coords"]
+    evt.annotations["spatial_scale"]
 
-    optical_flow = block.filter(name='optical_flow', objects="AnalogSignal")
+    # TBD: Add a try-except statement for correctly handling the absence of optical_flow signal
+    optical_flow = block.filter(name="optical_flow", objects="AnalogSignal")
     if not len(optical_flow):
-        warnings.warn('No Optical-Flow signal available!')
+        warnings.warn("No `optical_flow` signal available!")
 
-    evts = block.filter(name='wavemodes', objects="Event")
-    if len(evts):
-        print(f'{len(np.unique(evts[0].labels))} wavemodes found')
+    wavemodes = block.filter(name="wavemodes", objects="Event")
+    if len(wavemodes):
+        print(f'{len(np.unique(wavemodes[0].labels))} wavemodes found')
     else:
-        warnings.warn("No 'wavemodes' events found!")
+        warnings.warn("No `wavemodes` events found!")
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stage05_wave_characterization/scripts/check_input.py
+++ b/cobrawap/pipeline/stage05_wave_characterization/scripts/check_input.py
@@ -1,6 +1,5 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
@@ -9,29 +8,31 @@ import argparse
 from pathlib import Path
 import warnings
 import re
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 from utils.parse import none_or_str
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
-CLI.add_argument("--event_name", "--EVENT_NAME", nargs='?', type=none_or_str, default=None,
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
+CLI.add_argument("--event_name", "--EVENT_NAME", nargs="?", type=none_or_str, default=None,
                  help="name of neo.Event to analyze (must contain waves)")
-CLI.add_argument("--measures", "--MEASURES", nargs='+', type=none_or_str, default=None,
+CLI.add_argument("--measures", "--MEASURES", nargs="+", type=none_or_str, default=None,
                  help="list of measure names to apply")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
-    if args.measures is not None and args.event_name == 'wavemodes':
-        mode_invalid = ['label_planar', 'inter_wave_interval',
-                        'number_of_triggers', 'time_stamp']
+    if args.measures is not None and args.event_name == "wavemodes":
+        mode_invalid = ["label_planar", "inter_wave_interval",
+                        "number_of_triggers", "time_stamp"]
         args.measures = [re.sub(r"[\[\],\s]", "", measure) for measure in args.measures]
         invalid_measures = [measure for measure in args.measures \
                                                 if measure in mode_invalid]
         if len(invalid_measures):
-            warnings.warn('The following selected measures are can not be '
-                          'calculated for wavemodes and will be skipped: '
+            warnings.warn("The following selected measures are can not be "
+                          "calculated for wavemodes and will be skipped: "
                          f'{", ".join(invalid_measures)}.')
 
     block = load_neo(args.data)
@@ -40,12 +41,12 @@ if __name__ == '__main__':
         print("More than one Segment found; all except the first one " \
             + "will be ignored.")
 
-    evts = block.filter(name='wavefronts', objects="Event")
+    evts = block.filter(name="wavefronts", objects="Event")
     if not len(evts):
-        raise ValueError("No 'wavefronts' events found!")
+        raise ValueError("No `wavefronts` events found!")
 
     evt = evts[0]
-    evt = evt[evt.labels != '-1']
+    evt = evt[evt.labels != "-1"]
     num_waves = len(np.unique(evt.labels))
 
     if num_waves:
@@ -53,16 +54,19 @@ if __name__ == '__main__':
     else:
         raise ValueError("There are no waves detected!")
 
-    evt.array_annotations['x_coords']
-    evt.array_annotations['y_coords']
-    evt.annotations['spatial_scale']
+    evt.array_annotations["x_coords"]
+    evt.array_annotations["y_coords"]
+    evt.annotations["spatial_scale"]
 
-    evts = block.filter(name='optical_flow', objects="AnalogSignal")
-    if not len(evts):
-        warnings.warn('No Optical-Flow signal available!')
+    # TBD: Add a try-except statement for correctly handling the absence of optical_flow signal
+    optical_flow = block.filter(name="optical_flow", objects="AnalogSignal")
+    if not len(optical_flow):
+        warnings.warn("No `optical_flow` signal available!")
 
-    evts = block.filter(name='wavemodes', objects="Event")
-    if len(evts):
-        print(f'{len(np.unique(evts[0].labels))} wavemodes found')
+    wavemodes = block.filter(name="wavemodes", objects="Event")
+    if len(wavemodes):
+        print(f'{len(np.unique(wavemodes[0].labels))} wavemodes found')
     else:
-        warnings.warn("No 'wavemodes' events found!")
+        warnings.warn("No `wavemodes` events found!")
+
+    write_check(args.output)

--- a/cobrawap/pipeline/stageXY_template/scripts/check_input.py
+++ b/cobrawap/pipeline/stageXY_template/scripts/check_input.py
@@ -1,19 +1,20 @@
 """
-Check whether the input data representation adheres to the stage's requirements.
-
+Check whether the input data representation adheres to the stage requirements.
 Additionally prints a short summary of the data attributes.
 """
 
 import numpy as np
 import argparse
 from pathlib import Path
-from utils.io_utils import load_neo
+from utils.io_utils import load_neo, write_check
 
 CLI = argparse.ArgumentParser()
-CLI.add_argument("--data", nargs='?', type=Path, required=True,
+CLI.add_argument("--data", nargs="?", type=Path, required=True,
                  help="path to input data in neo format")
+CLI.add_argument("--output", nargs="?", type=Path, required=True,
+                 help="path of output check file")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args, unknown = CLI.parse_known_args()
 
     block = load_neo(args.data)
@@ -27,15 +28,17 @@ if __name__ == '__main__':
 
     asig = block.segments[0].analogsignals[0]
 
-    print('Recording Time:\t\t', asig.t_stop - asig.t_start)
-    print('Sampling Rate:\t\t', asig.sampling_rate)
-    print('Spatial Scale:\t\t', asig.annotations['spatial_scale'])
+    print("Recording Time:\t\t", asig.t_stop - asig.t_start)
+    print("Sampling Rate:\t\t", asig.sampling_rate)
+    print("Spatial Scale:\t\t", asig.annotations["spatial_scale"])
 
     num_channels = np.count_nonzero(~np.isnan(np.sum(asig, axis=0)))
-    print('Number of Channels:\t', num_channels)
+    print("Number of Channels:\t", num_channels)
 
-    x_coords = asig.array_annotations['x_coords']
-    y_coords = asig.array_annotations['y_coords']
+    x_coords = asig.array_annotations["x_coords"]
+    y_coords = asig.array_annotations["y_coords"]
     dim_x, dim_y = np.max(x_coords)+1, np.max(y_coords)+1
-    print('Grid Dimensions:\t', f'{dim_x} x {dim_y}')
-    print('Empty Grid Sites:\t', dim_x*dim_y - num_channels)
+    print("Grid Dimensions:\t", f'{dim_x} x {dim_y}')
+    print("Empty Grid Sites:\t", dim_x*dim_y - num_channels)
+
+    write_check(args.output)

--- a/cobrawap/pipeline/utils/Snakefile
+++ b/cobrawap/pipeline/utils/Snakefile
@@ -9,29 +9,31 @@ from utils.parse import parse_plot_channels
 from utils.snakefile import dict_to_cla, params, locate_str_in_list
 from utils.snakefile import get_setting
 
-CONFIG_PATH = Path(get_setting('config_path'))
-OUTPUT_PATH = Path(get_setting('output_path'))
+CONFIG_PATH = Path(get_setting("config_path"))
+OUTPUT_PATH = Path(get_setting("output_path"))
 
-is_first_stage = config['STAGE_NAME'] == get_setting('stages')['1']
+is_first_stage = config["STAGE_NAME"] == get_setting("stages")["1"]
 if is_first_stage:
-    config['STAGE_INPUT'] = None
-if 'STAGE_INPUT' not in config:
-    logger.warning('No STAGE_INPUT defined for running stage \'{}\' individually! '.format(config['STAGE_NAME']) +
-                   'You can set it via the command line with ' +
-                   '`--config STAGE_INPUT=/path/to/file`.')
+    config["STAGE_INPUT"] = None
+if "STAGE_INPUT" not in config:
+    err = "No STAGE_INPUT defined for running stage \'" \
+          + config["STAGE_NAME"] + "\' individually! " \
+	  + "You can set it via the command line with " \
+	  + "`--config STAGE_INPUT=/path/to/file`."
+    logger.warning(err)
 
-if 'USE_LINK_AS_STAGE_OUTPUT' not in config:
-    config['USE_LINK_AS_STAGE_OUTPUT'] = True
+if "USE_LINK_AS_STAGE_OUTPUT" not in config:
+    config["USE_LINK_AS_STAGE_OUTPUT"] = True
 
 config = SimpleNamespace(**config)
 ADD_UTILS = str("export PYTHONPATH='$PYTHONPATH:%s'" % utils_path)
 OUTPUT_DIR = OUTPUT_PATH / config.PROFILE / config.STAGE_NAME
-SCRIPTS = Path(inspect.getfile(lambda: None)).parents[1].resolve() / config.STAGE_NAME / 'scripts'
+SCRIPTS = Path(inspect.getfile(lambda: None)).parents[1].resolve() / config.STAGE_NAME / "scripts"
 
-config.PLOT_FORMAT = config.PLOT_FORMAT.strip('.')
-if hasattr(config, 'NEO_FORMAT'):
-    config.NEO_FORMAT = config.NEO_FORMAT.strip('.')
-    if not '.' in config.STAGE_OUTPUT:
+config.PLOT_FORMAT = config.PLOT_FORMAT.strip(".")
+if hasattr(config, "NEO_FORMAT"):
+    config.NEO_FORMAT = config.NEO_FORMAT.strip(".")
+    if not "." in config.STAGE_OUTPUT:
         config.STAGE_OUTPUT += "." + config.NEO_FORMAT
 
 if config.STAGE_INPUT is not None:
@@ -52,7 +54,7 @@ def prev_rule_output(wildcards, rule_list,
                      default_input=config.STAGE_INPUT):
     output = lambda i: OUTPUT_DIR / rule_list[i-1] \
                                   / str(rule_list[i-1] + "." + config.NEO_FORMAT)
-    if hasattr(wildcards, 'rule_name'):
+    if hasattr(wildcards, "rule_name"):
         idx = locate_str_in_list(rule_list, wildcards.rule_name)
         if idx:
             return output(idx)
@@ -138,8 +140,7 @@ rule check_input:
     shell:
         """
         {ADD_UTILS}
-        python3 {input.script:q} --data {input.data:q}
-        touch {output:q}
+        python3 {input.script:q} --data {input.data:q} --output {output:q}
         """
 
 

--- a/cobrawap/pipeline/utils/Snakefile
+++ b/cobrawap/pipeline/utils/Snakefile
@@ -16,10 +16,10 @@ is_first_stage = config["STAGE_NAME"] == get_setting("stages")["1"]
 if is_first_stage:
     config["STAGE_INPUT"] = None
 if "STAGE_INPUT" not in config:
-    err = "No STAGE_INPUT defined for running stage \'" \
-          + config["STAGE_NAME"] + "\' individually! " \
-	  + "You can set it via the command line with " \
-	  + "`--config STAGE_INPUT=/path/to/file`."
+    err = f"No STAGE_INPUT defined for running stage \'"
+          f"{config['STAGE_NAME']}\' individually! "
+	   "You can set it via the command line with "
+	   "`--config STAGE_INPUT=/path/to/file`."
     logger.warning(err)
 
 if "USE_LINK_AS_STAGE_OUTPUT" not in config:
@@ -46,7 +46,7 @@ wildcard_constraints:
     data_name = r"[\w\-]+",
     dir = r".*",
     rule_name = r"\w+",
-    # Allowing integers, floats and "None"
+    # Allowing integers, floats, and "None"
     t_start = r"^[0-9]+$|^[0-9]+.[0-9]+$|^None$",
     t_stop = r"^[0-9]+$|^[0-9]+.[0-9]+$|^None$",
 

--- a/cobrawap/pipeline/utils/io_utils.py
+++ b/cobrawap/pipeline/utils/io_utils.py
@@ -1,9 +1,10 @@
-import os
-import neo
 import matplotlib.pyplot as plt
+import neo
+import os
 import warnings
-from snakemake.logging import logger
 from pathlib import Path
+from snakemake.logging import logger
+
 
 def load_neo(filename, object='block', lazy=False, *args, **kwargs):
     try:
@@ -51,6 +52,15 @@ def write_neo(filename, block, *args, **kwargs):
         warnings.warn(str(e))
     finally:
         nio.close()
+    return True
+
+
+def write_check(filename="input.check"):
+    # creates an empty file, typically named `input.check`
+    try:
+        Path(filename).touch(exist_ok=True)
+    except Exception as e:
+        warnings.warn(str(e))
     return True
 
 


### PR DESCRIPTION
As a preparatory step for CWL integration into Cobrawap as an alternative workflow manager, this PR proposes a different logic for the creation of `input.check` files.
The old method consisted in `check_input.py` blocks just reading neo files and checking for their consistency, producing no output files. Snakemake rule `check_input` was then explicitly asked for the creation of such files, via the shell command `touch`.
In the new approach, it is the `check_input.py` block itself that creates an empty output file named `input.check`, at the end of consistency checks and hence only after their successful ending. `--output` command-line argument is then added to such blocks. Snakemake rule `check_input` is changed accordingly, removing the shell command and adding the `output` field typically used for standard I/O blocks.
This new approach greatly helps in the I/O binding between steps in CWL workflows.